### PR TITLE
Initial support for configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+
+# chat
+
+## Configuration
+
+Chat server looks for a configuration file `config.yaml` with following configuration options:
+
+* `server.port`: Port number which server should listen to.
+* `database.filename`: Path to the SQLite database file. Besides absolute or relative path, two special values are supported: `:memory:` for an in-memory database and empty string for temporary anonymous disk-based database.
+
+See `config.yaml.example` for an example and default values.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,6 @@
+---
+server:
+  port: 3000
+
+database:
+  filename: ""

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.14.1",
+    "js-yaml": "^3.8.1",
     "socket.io": "^1.7.3",
     "sqlite3": "^3.1.8"
   }


### PR DESCRIPTION
This PR adds configuration file support for chat server. This allows system operator to change backend server listening port and database file configurations.

Changes include:
* A new dependency for parsing YAML
* Code for reading and normalizing configuration
* Configuration example
* Documentation as JSDoc and readme

Currently, configuration file path is hardcoded, which leaves room for future improvement.